### PR TITLE
Fix netlist warnings

### DIFF
--- a/xschem/bias_generator_idac_be.sch
+++ b/xschem/bias_generator_idac_be.sch
@@ -391,8 +391,6 @@ N -1320 120 -1290 120 {
 lab=ena[6]}
 C {devices/iopin.sym} -1330 -60 0 1 {name=p39 lab=avss}
 C {devices/iopin.sym} -1340 -490 0 1 {name=p42 lab=avdd}
-C {devices/lab_wire.sym} -1270 -450 0 0 {name=p44 sig_type=std_logic lab=pbias}
-C {devices/lab_wire.sym} -1270 -470 0 0 {name=p45 sig_type=std_logic lab=pcasc}
 C {bias_nstack.sym} -1100 -140 0 0 {name=x3}
 C {bias_pstack.sym} -1060 -360 0 0 {name=x1}
 C {bias_pstack.sym} -690 -360 0 0 {name=x8}

--- a/xschem/bias_pstack.sch
+++ b/xschem/bias_pstack.sch
@@ -73,7 +73,6 @@ model=pfet_g5v0d10v5
 spiceprefix=X
 }
 C {devices/ipin.sym} 100 -330 0 0 {name=p12 lab=enb}
-C {devices/lab_wire.sym} 130 -510 0 0 {name=p16 sig_type=std_logic lab=pbias}
 C {sky130_fd_pr/pfet_g5v0d10v5.sym} 170 -430 0 0 {name=M14
 W=3
 L=1
@@ -88,7 +87,6 @@ sa=0 sb=0 sd=0
 model=pfet_g5v0d10v5
 spiceprefix=X
 }
-C {devices/lab_wire.sym} 130 -430 0 0 {name=p17 sig_type=std_logic lab=pcasc}
 C {devices/ipin.sym} 60 -430 0 0 {name=p1 lab=pcasc}
 C {devices/iopin.sym} 60 -380 0 1 {name=p2 lab=vcasc}
 C {devices/ipin.sym} 60 -510 0 0 {name=p3 lab=pbias}


### PR DESCRIPTION
Input pins and wire labels on the same wire cause netlist shorted output warnings. This commit removes the redundant wire label.

These are the warnings that will be removed
```
-----------.../sky130_ef_ip__biasgen/xschem/bias_generator_idac_be.sch
Warning: shorted output node: pcasc
Warning: shorted output node: pbias
-----------.../sky130_ef_ip__biasgen/xschem/bias_pstack.sch
Warning: shorted output node: pcasc
Warning: shorted output node: pbias
```
Here are screenshots of the origin circuit showing input pins and wire labels on the same net.
<img width="427" alt="スクリーンショット 2024-11-16 12 17 09" src="https://github.com/user-attachments/assets/ce881212-97a8-40a5-8029-ad2d95ef8b42">
<img width="390" alt="スクリーンショット 2024-11-16 12 16 03" src="https://github.com/user-attachments/assets/c31b38c0-5134-48a7-a062-be4c770dc222">

@RTimothyEdwards these changes are not critical and do not affect the final netlist.
